### PR TITLE
Create an entry for the empty attachments dir

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -135,6 +135,7 @@ func addAttachmentsToTheZipFile(dpConfig map[string]string, dpPath string, zipFi
 		attachUri = filepath.Join(dpPath, "attachments")
 	}
 
+	zipFile.Create("attachments/")
 	addFilesToTheZip(zipFile, attachUri, "attachments")
 	fmt.Println("\t Done writing attachments")
 }


### PR DESCRIPTION
If the attachments directory is empty, then the final backup archive
won't have an entry for the (empty) attachments directory, which will
break the restore process from an archive. Creating a file into the
writer with a slash appended creates the directory entry