### PR TITLE
Use zip package fork to encrypt the entire zip

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -53,6 +53,10 @@ func init() {
 		"",
 		`
 				Provide a secret to use to encrypt the database dump.
+				
+				Note that providing with this flag will encrypt the backup using
+				the AES encryption method so any application that is required to
+				extract the archive will need to support this encyption method.
 		`,
 	)
 

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -1,11 +1,7 @@
 package cmd
 
 import (
-	"archive/zip"
 	"bytes"
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/rand"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -15,10 +11,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alexmullins/zip"
 	"github.com/cheggaaa/pb/v3"
 	"github.com/deskpro/dputils/util"
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/scrypt"
 )
 
 func init() {
@@ -127,7 +123,7 @@ var backupCmd = &cobra.Command{
 			addDumpToTheZipFile(dpConfig, "system", zipFileWriter, encryptionSecret)
 		}
 		if what == "attachments" || what == "" {
-			addAttachmentsToTheZipFile(dpConfig, Config.DpPath(), zipFileWriter)
+			addAttachmentsToTheZipFile(dpConfig, Config.DpPath(), zipFileWriter, encryptionSecret)
 		}
 
 		if target == "public" {
@@ -138,7 +134,7 @@ var backupCmd = &cobra.Command{
 	},
 }
 
-func addAttachmentsToTheZipFile(dpConfig map[string]string, dpPath string, zipFile *zip.Writer) {
+func addAttachmentsToTheZipFile(dpConfig map[string]string, dpPath string, zipFile *zip.Writer, encryptionSecret string) {
 	fmt.Println("Writing attachments")
 	var attachUri string
 	if val, ok := dpConfig["paths.dp_paths.attachments"]; ok {
@@ -147,12 +143,12 @@ func addAttachmentsToTheZipFile(dpConfig map[string]string, dpPath string, zipFi
 		attachUri = filepath.Join(dpPath, "attachments")
 	}
 
-	zipFile.Create("attachments/")
-	addFilesToTheZip(zipFile, attachUri, "attachments")
+	util.ZipCreate(zipFile, "attachments/", encryptionSecret)
+	addFilesToTheZip(zipFile, attachUri, "attachments", encryptionSecret)
 	fmt.Println("\t Done writing attachments")
 }
 
-func addFilesToTheZip(zipFile *zip.Writer, uri string, zipPath string) {
+func addFilesToTheZip(zipFile *zip.Writer, uri string, zipPath string, encryptionSecret string) {
 	files, err := ioutil.ReadDir(uri)
 	if err != nil {
 		fmt.Println(err)
@@ -173,7 +169,7 @@ func addFilesToTheZip(zipFile *zip.Writer, uri string, zipPath string) {
 				fmt.Println(err)
 			}
 
-			f, err := zipFile.Create(filepath.Join(zipPath, file.Name()))
+			f, err := util.ZipCreate(zipFile, filepath.Join(zipPath, file.Name()), encryptionSecret)
 			if err != nil {
 				fmt.Println(err)
 			}
@@ -192,7 +188,7 @@ func addFilesToTheZip(zipFile *zip.Writer, uri string, zipPath string) {
 		} else if file.IsDir() {
 			newBase := filepath.Join(uri, file.Name(), "")
 			bar.Increment()
-			addFilesToTheZip(zipFile, newBase, filepath.Join(zipPath, file.Name(), ""))
+			addFilesToTheZip(zipFile, newBase, filepath.Join(zipPath, file.Name()), encryptionSecret)
 		}
 	}
 	bar.Finish()
@@ -245,17 +241,11 @@ func addDumpToTheZipFile(dpConfig map[string]string, dbType string, zipFile *zip
 
 	dumpCmd.Stdout = writer
 	dumpCmd.Stderr = &dumpBuff
-	zipWriter, _ := zipFile.Create(prefix + ".sql")
+	zipWriter, _ := util.ZipCreate(zipFile, prefix+".sql", encryptionSecret)
 	go func() {
 		defer reader.Close()
-		if encryptionSecret == "" {
-			if _, err := io.Copy(zipWriter, reader); err != nil {
-				fmt.Println(err)
-			}
-		} else {
-			if err := encryptDump(reader, zipWriter, encryptionSecret); err != nil {
-				fmt.Println(err)
-			}
+		if _, err := io.Copy(zipWriter, reader); err != nil {
+			fmt.Println(err)
 		}
 	}()
 
@@ -267,101 +257,4 @@ func addDumpToTheZipFile(dpConfig map[string]string, dbType string, zipFile *zip
 		os.Exit(1)
 	}
 	fmt.Println("\tDone writing the " + dbName + " dump file to zip archive")
-}
-
-// Encrypt the stream using the given AES-CTR key
-func encryptDump(in io.Reader, out io.Writer, secret string) error {
-	saltSize := 32 // 256 bits
-	salt, err := randBytes(saltSize)
-	if err != nil {
-		fmt.Println(err)
-		return err
-	}
-	keyAes, err := deriveKeys([]byte(secret), salt)
-	if err != nil {
-		fmt.Println(err)
-		return err
-	}
-
-	ivSize := 16
-	iv := make([]byte, ivSize)
-	_, err = rand.Read(iv)
-	if err != nil {
-		fmt.Println(err)
-		return err
-	}
-
-	AES, err := aes.NewCipher(keyAes)
-	if err != nil {
-		fmt.Println(err)
-		return err
-	}
-
-	ctr := cipher.NewCTR(AES, iv)
-
-	_, err = out.Write(salt)
-	if err != nil {
-		fmt.Println(err)
-		return err
-	}
-
-	_, err = out.Write(iv)
-	if err != nil {
-		fmt.Println(err)
-		return err
-	}
-
-	bufferSize := 16 * 1024
-	buf := make([]byte, bufferSize)
-	for {
-		n, err := in.Read(buf)
-		if err != nil {
-			if err != io.EOF {
-				fmt.Println(err)
-				return err
-			}
-		}
-
-		if n != 0 {
-			outBuf := make([]byte, n)
-			ctr.XORKeyStream(outBuf, buf[:n])
-			_, err = out.Write(outBuf)
-			if err != nil {
-				fmt.Println(err)
-				return err
-			}
-		}
-
-		if err == io.EOF {
-			fmt.Println(err)
-			break
-		}
-	}
-
-	return nil
-}
-
-// Derives AES key from a password and salt.
-func deriveKeys(pass, salt []byte) ([]byte, error) {
-	// The number of iterations to use in for key generation
-	// See N value in https://godoc.org/golang.org/x/crypto/scrypt#Key
-	// Must be a power of 2.
-	iterations := int(262144) // 2^18
-
-	keySize := 32 // 256 bits - The size of the AES key.
-	key, err := scrypt.Key(pass, salt, iterations, 8, 1, keySize)
-	if err != nil {
-		fmt.Println(err)
-		return nil, err
-	}
-	aesKey := []byte{}
-	aesKey = append(aesKey, key[:keySize]...)
-	return aesKey, nil
-}
-
-// randBytes returns random bytes in a byte slice of size.
-func randBytes(size int) ([]byte, error) {
-	b := make([]byte, size)
-	_, err := rand.Read(b)
-	return b, err
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
+	github.com/alexmullins/zip v0.0.0-20180717182244-4affb64b04d0 // indirect
 	github.com/cheggaaa/pb/v3 v3.0.8
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-sql-driver/mysql v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/alexmullins/zip v0.0.0-20180717182244-4affb64b04d0 // indirect
+	github.com/alexmullins/zip v0.0.0-20180717182244-4affb64b04d0
 	github.com/cheggaaa/pb/v3 v3.0.8
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-sql-driver/mysql v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20O
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
+github.com/alexmullins/zip v0.0.0-20180717182244-4affb64b04d0 h1:BVts5dexXf4i+JX8tXlKT0aKoi38JwTXSe+3WUneX0k=
+github.com/alexmullins/zip v0.0.0-20180717182244-4affb64b04d0/go.mod h1:FDIQmoMNJJl5/k7upZEnGvgWVZfFeE6qHeN7iCMbCsA=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/util/zip.go
+++ b/util/zip.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"io"
+
+	"github.com/alexmullins/zip"
+)
+
+func ZipCreate(writer *zip.Writer, name string, secret string) (io.Writer, error) {
+	if secret == "" {
+		return writer.Create(name)
+	} else {
+		return writer.Encrypt(name, secret)
+	}
+}


### PR DESCRIPTION
This change uses the zip package by Alex Mullins (https://github.com/alexmullins/zip) to directly replace the inbuilt go zip package because it supports password encryption and decryption. The increase in size is negligible because the files are encrypted after compression as outlined here: https://www.winzip.com/en/support/aes-encryption/
> Encrypted file data
Encryption is applied only to the content of files. It is performed after compression, and not to any other associated data. The file data is encrypted byte-for-byte using the AES encryption algorithm operating in "CTR" mode, which means that the lengths of the compressed data and the compressed, encrypted data are the same.