### PR TITLE
add Horizon checks metadata to a backup

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -264,7 +264,6 @@ func addDumpToTheZipFile(dpConfig map[string]string, dbType string, zipFile *zip
 	fmt.Println("\tDone writing the " + dbName + " dump file to zip archive")
 }
 
-// php /usr/share/nginx/html/deskpro/bin/console dp:utility:deskpro-horizon-check-reqs
 func addMetadataToTheZipFile(dpConfig map[string]string, config *util.Config, zipFile *zip.Writer, encryptionSecret string) {
 	out, err := exec.Command(config.PhpPath(), filepath.Join(config.DpPath(), "bin", "console"), "dp:utility:deskpro-horizon-check-reqs").Output()
 	if err != nil {

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -283,10 +283,14 @@ func addMetadataToTheZipFile(dpConfig map[string]string, config *util.Config, zi
 	f, err := util.ZipCreate(zipFile, "v5_metadata.json", encryptionSecret)
 	if err != nil {
 		fmt.Println(err)
+		fmt.Println("\tFailed writing metadata")
+		return
 	}
 	_, err = f.Write(out)
 	if err != nil {
 		fmt.Println(err)
+		fmt.Println("\tFailed writing metadata")
+		return
 	}
 
 	fmt.Println("\tDone writing metadata")

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -125,6 +125,7 @@ var backupCmd = &cobra.Command{
 			addDumpToTheZipFile(dpConfig, "audit", zipFileWriter, encryptionSecret)
 			addDumpToTheZipFile(dpConfig, "voice", zipFileWriter, encryptionSecret)
 			addDumpToTheZipFile(dpConfig, "system", zipFileWriter, encryptionSecret)
+			addMetadataToTheZipFile(dpConfig, &Config, zipFileWriter, encryptionSecret)
 		}
 		if what == "attachments" || what == "" {
 			addAttachmentsToTheZipFile(dpConfig, Config.DpPath(), zipFileWriter, encryptionSecret)
@@ -261,4 +262,33 @@ func addDumpToTheZipFile(dpConfig map[string]string, dbType string, zipFile *zip
 		os.Exit(1)
 	}
 	fmt.Println("\tDone writing the " + dbName + " dump file to zip archive")
+}
+
+// php /usr/share/nginx/html/deskpro/bin/console dp:utility:deskpro-horizon-check-reqs
+func addMetadataToTheZipFile(dpConfig map[string]string, config *util.Config, zipFile *zip.Writer, encryptionSecret string) {
+	out, err := exec.Command(config.PhpPath(), filepath.Join(config.DpPath(), "bin", "console"), "dp:utility:deskpro-horizon-check-reqs").Output()
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			if exitError.ExitCode() == 1 {
+				// exit code of 1 means the command does not exist
+				return
+			}
+		} else {
+			// couldn't get exit code
+			return
+		}
+	}
+
+	fmt.Println("Writing metadata")
+
+	f, err := util.ZipCreate(zipFile, "v5_metadata.json", encryptionSecret)
+	if err != nil {
+		fmt.Println(err)
+	}
+	_, err = f.Write(out)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	fmt.Println("\tDone writing metadata")
 }


### PR DESCRIPTION
Add the output of `bin/console dp:utility:deskpro-horizon-check-reqs` to the backup (if a database is to be included in the backup).

If the command exits with exit code 1, the assumption is that the version of V5 is older than the most recent version and the command doesn't exist so no output will be included in the backup/

If the exit code > 1, the command exists and has returned some errors which will be written to the `v5_metadata.json` file.

If the exit code is 0, the command exists and no errors were found - the output of the command will still be written to the  `v5_metadata.json` file so it can be verified by OPC.